### PR TITLE
Drop support for PHP 7.4 / 8.0 on PHPUnit 10

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.1', '8.2', '8.3' ]
         wp-versions: [ 'latest' ]
 
     name: WordPress ${{ matrix.wp-versions }} / PHP ${{ matrix.php-versions }}
@@ -42,8 +42,8 @@ jobs:
     - name: Check PHP Version
       run: php -v
 
-    - name: Composer update
-      run: composer update --optimize-autoloader --prefer-dist
+    - name: Composer install
+      run: composer install --optimize-autoloader --prefer-dist
 
     - name: Install WP Tests
       run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 ${{ matrix.wp-versions }}


### PR DESCRIPTION
## Overview

Drop support for PHP 7.4 / 8.0 on [PHPUnit 10](https://phpunit.de/announcements/phpunit-10.html)