### PR TITLE
fix: prevent null order parameter in spreadsheet table sorting

### DIFF
--- a/admin/class-recursivetable.php
+++ b/admin/class-recursivetable.php
@@ -185,6 +185,7 @@ declare(strict_types=1);
 	);
 
 	// Sort column validation.
+	$order   = $order ?? $default_order;
 	$orderby = isset( $allowed_orderby[ $orderby ] ) ? $orderby : $default_orderby;
 	$order   = in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ? strtoupper( $order ) : $default_order;
 


### PR DESCRIPTION
- Add null coalescing operator to handle null order parameter
- Set default order to 'DESC' when order is not specified
- Validate and sanitize order parameter before use
- Improve code readability and prevent potential TypeError
